### PR TITLE
 Strip newline character in transaction description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /dist/
 /docs/build/
 /docs/source/api/
+.vscode/
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - Fix newline in transaction description messing with CSV output
 
 ## [0.2] - 2021-02-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 - Fix newline in transaction description messing with CSV output
+
+## [0.2] - 2021-02-07
+
+- Hotfix
 
 ## [0.1] - 2021-02-03
 
@@ -16,8 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [Cembra & Cumulus](https://www.cembra.ch/en/cards/cembra-mastercard/) MasterCard
   - [Swisscard Cashback](https://www.swisscard.ch/en/private-customers/products) (AMEX / VISA / MasterCard)
 
-## [0.2] - 2021-02-07
-
-- Hotfix
-
+[Unreleased]: https://github.com/c-vigo/StatementPDFImporter/compare/v0.2...HEAD
+[0.2]: https://github.com/c-vigo/StatementPDFImporter/tree/v0.2
 [0.1]: https://github.com/c-vigo/StatementPDFImporter/tree/v0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fix newline in transaction description messing with CSV output
+
 ## [0.1] - 2021-02-03
 
 - First version of the package
@@ -12,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [Cembra & Cumulus](https://www.cembra.ch/en/cards/cembra-mastercard/) MasterCard
   - [Swisscard Cashback](https://www.swisscard.ch/en/private-customers/products) (AMEX / VISA / MasterCard)
 
-
 ## [0.2] - 2021-02-07
+
 - Hotfix
-    
+
 [0.1]: https://github.com/c-vigo/StatementPDFImporter/tree/v0.1

--- a/pdf_importer/Importers.py
+++ b/pdf_importer/Importers.py
@@ -58,7 +58,7 @@ def extract_cashback(filename):
     for index, row in df.iterrows():
         try:
             date = parse(row[0].strip(), dayfirst=True).date()
-            text = row[1]
+            text = row[1].replace("\n", " ")
             amount = -float(row[2])
 
             entries.append([date, amount, text])


### PR DESCRIPTION
This PR the issue #2.
@c-vigo I moved some stuff around in the CHANGELOG.md file. If you prefer how it was before, I can revert the changes.

Same for the .gitignore